### PR TITLE
Remove Braintree alert email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: android
 jdk: oraclejdk8
-notifications:
-  email:
-    - external-ci-notifications+android-card-form@getbraintree.com
 sudo: true
 android:
   components:


### PR DESCRIPTION
This email alerts the Braintree team when CI fails